### PR TITLE
add engines at package json

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,9 @@
       "license": "ISC",
       "dependencies": {
         "blessed": "^0.1.81"
+      },
+      "engines": {
+        "node": ">=14.8.0"
       }
     },
     "node_modules/blessed": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,7 @@
         "blessed": "^0.1.81"
       },
       "engines": {
-        "node": ">=14.8.0"
+        "node": ">=15.12.0"
       }
     },
     "node_modules/blessed": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": ">=14.8.0"
+    "node": ">=15.12.0"
   },
   "scripts": {
     "start": "node index.js",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "index.js",
   "type": "module",
+  "engines": {
+    "node": ">=14.8.0"
+  },
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
some features used at project needs a recent node support version, so I think is important block users that try install and
use the application with older versions.

The most recent feature used in project is top-level async/await without using flags, this is a feature implemented in node 14.8